### PR TITLE
Update main js file path in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ bower install winjs
 Reference the script from your HTML:
 
 ```html
-<script src="/bower_components/winjs/winjs.js"></script>
+<script src="/bower_components/winjs/js/WinJS.js"></script>
 ```


### PR DESCRIPTION
The path for WinJS.js seems to be wrong in README.md.
